### PR TITLE
add a constant style to widget  to overwrite theme style

### DIFF
--- a/src/main/frontend/src/components/Widgets/WidgetView.js
+++ b/src/main/frontend/src/components/Widgets/WidgetView.js
@@ -17,11 +17,12 @@ const Widget = ({
   className,
   header,
   customBackGround,
+  overwriteBackGround,
   titleClass,
   ...props
 }) => (
   <div className={classes.widgetWrapper}>
-    <Paper className={classnames(classes.paper,{[classes.customBackGround]:customBackGround})} classes={{ root: classes.widgetRoot }}>
+    <Paper className={classnames(classes.paper,overwriteBackGround,{[classes.customBackGround]:customBackGround})} classes={{ root: classes.widgetRoot }}>
       <div id={title} className={classes.widgetHeader}>
         {props.header ? (
           props.header

--- a/src/main/frontend/src/pages/trialDetail/trialDetailView.js
+++ b/src/main/frontend/src/pages/trialDetail/trialDetailView.js
@@ -387,6 +387,7 @@ const TrialView = ({ classes, data, theme }) => {
                     color={theme.palette.dodgeBlue.main}
                     titleClass={classes.widgetTitle}
                     customBackGround
+                    overwriteBackGround={classes.overwriteBackGround}
                   >
                     <CustomActiveDonut
                       data={widgetData.diagnosis}
@@ -765,6 +766,9 @@ const styles = (theme) => ({
   },
   tableCell5: {
     width: '160px',
+  },
+  overwriteBackGround: {
+    background: '#F3F8FB',
   },
 });
 


### PR DESCRIPTION
add a constant style to the widget  to overwrite theme style, that is, widget in the trial detail page will not be affected by theme change.